### PR TITLE
metrics, metrics everywhere

### DIFF
--- a/scripts/runnable_recipe_ray_vllm_weight_sync.py
+++ b/scripts/runnable_recipe_ray_vllm_weight_sync.py
@@ -645,6 +645,7 @@ class vLLMRolloutActor:
                 )
 
                 # Capture peak GPU memory usage
+                # TODO: training.get_memory_stats() crashes vLLM
                 gpu_memory_peak_allocated = torch.cuda.max_memory_allocated(
                     device="cuda:0"
                 )

--- a/scripts/runnable_recipe_ray_vllm_weight_sync.py
+++ b/scripts/runnable_recipe_ray_vllm_weight_sync.py
@@ -112,15 +112,12 @@ class RefActor:
         assert "actor_queue" in kwargs, "Must pass queue to vLLMRefActor"
         assert "cfg" in kwargs, "Must pass cfg to vLLMRefActor"
 
-        world_size, rank = utils.get_world_size_and_rank()
-        self.rank = rank
-        self.world_size = world_size
-        self._is_rank_zero = rank == 0
+        self.actor_id = kwargs.pop("actor_id", 0)
+        self._is_actor_zero = self.actor_id == 0
 
         self.cfg = kwargs.pop("cfg")
         self.rollout_replay_buffer = kwargs.pop("rollout_queue")
         self.actor_replay_buffer = kwargs.pop("actor_queue")
-        # self.llm = LLM(*args, **kwargs)
         self._device = utils.get_device(device=self.cfg.device)
         self._dtype = training.get_dtype(self.cfg.dtype, device=self._device)
         ref_checkpoint_dict = self.load_ref_checkpoint(
@@ -130,6 +127,12 @@ class RefActor:
             self.cfg.model, ref_checkpoint_dict[training.MODEL_KEY]
         )
         self._temperature = self.cfg.temperature
+
+        self.metric_logger = None  # Placeholder for the logger
+
+    def set_metric_logger(self, logger):
+        """Store the MetricLoggerActor handle."""
+        self._metric_logger = logger
 
     def load_ref_checkpoint(self, cfg_ref_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -181,10 +184,12 @@ class RefActor:
             if idx == 400:
                 break
 
+            # Start measuring total step time
+            time_step_start = time.perf_counter()
             trajectory = None
             while trajectory is None:
                 try:
-                    if self._is_rank_zero:
+                    if self._is_actor_zero:
                         print(
                             f"Getting from queue RefActor. Replay buffer size at start: {self.rollout_replay_buffer.qsize()}"
                         )
@@ -202,6 +207,8 @@ class RefActor:
                 except Exception:
                     trajectory = None
                     time.sleep(0.1)
+            time_wait_end = time.perf_counter()
+            time_waiting_for_buffer = time_wait_end - time_step_start
 
             (
                 query_responses,
@@ -210,6 +217,7 @@ class RefActor:
                 query_response_padding_masks,
                 seq_lens,
                 answers,
+                policy_version,
             ) = trajectory
 
             context_length = query_responses.shape[1] - responses.shape[1]
@@ -221,19 +229,29 @@ class RefActor:
                 query_response_padding_masks
             )
 
+            # Reset GPU memory stats before computation
+            torch.cuda.reset_peak_memory_stats()
+
+            compute_start = time.perf_counter()
             with torch.no_grad():
                 ref_logits = self._ref_model(
                     query_responses, input_pos=position_ids, mask=masks
                 )
-
             ref_logits = rlhf.truncate_sequence_for_logprobs(ref_logits, context_length)
             ref_logprobs = rlhf.batched_logits_to_logprobs(
                 ref_logits, responses, self._temperature
             )
+            compute_end = time.perf_counter()
+            time_computation = compute_end - compute_start
+
+            # Capture peak GPU memory usage
+            gpu_memory_peak_allocated = torch.cuda.max_memory_allocated()
+            gpu_memory_peak_reserved = torch.cuda.max_memory_reserved()
 
             del ref_logits, position_ids, masks
             # masking of ref_logprobs is done in grpo_step
 
+            # Repack trajectory with policy_version
             trajectory = (
                 query_responses,
                 responses,
@@ -242,6 +260,7 @@ class RefActor:
                 query_response_padding_masks,
                 seq_lens,
                 answers,
+                policy_version,
             )
             print("putting trajectory into actor queue")
 
@@ -252,6 +271,7 @@ class RefActor:
             ]
 
             # Update circular queue
+            full_queue_retries = 0
             while True:
                 try:
                     print(
@@ -261,9 +281,38 @@ class RefActor:
                     break
                 except QueueFull:
                     self.actor_replay_buffer.get()  # Remove the oldest item to make space
+                    full_queue_retries += 1
                     print(
                         f"RefActor queue size after get: {self.actor_replay_buffer.qsize()}"
                     )
+
+            # End of step timing
+            time_total_ref_step = time.perf_counter() - time_step_start
+
+            # Compute percentage of time computing
+            pct_time_computing = (
+                (time_computation / time_total_ref_step) * 100
+                if time_total_ref_step > 0
+                else 0
+            )
+
+            # Prepare metrics dictionary
+            div_GiB = 1024**3
+            log_dict = {
+                "ref_actor_performance/time_total_ref_step": time_total_ref_step,
+                "ref_actor_performance/pct_time_computing": pct_time_computing,
+                "ref_actor_performance/gpu_memory_peak_allocated": gpu_memory_peak_allocated
+                / div_GiB,
+                "ref_actor_performance/gpu_memory_peak_reserved": gpu_memory_peak_reserved
+                / div_GiB,
+                "ref_actor_performance/time_waiting_for_buffer": time_waiting_for_buffer,
+                "queues/ref_actor_full_queue_retries": full_queue_retries,
+                "queues/rollout_replay_buffer_size": self.rollout_replay_buffer.qsize(),
+                "queues/actor_replay_buffer_size": self.actor_replay_buffer.qsize(),
+            }
+
+            # Log metrics
+            ray.get(self._metric_logger.log_dict.remote(log_dict, step=idx))
 
             torch.cuda.empty_cache()
 
@@ -272,6 +321,13 @@ class RefActor:
 
 class vLLMRolloutActor:
     def __init__(self, *args, **kwargs):
+        import os
+
+        import torch
+
+        print(f"Actor CUDA_VISIBLE_DEVICES: {os.environ.get('CUDA_VISIBLE_DEVICES')}")
+        print(f"Device count: {torch.cuda.device_count()}")
+
         assert "queue" in kwargs, "Must pass queue to vLLMRolloutActor"
         assert "cfg" in kwargs, "Must pass cfg to vLLMRolloutActor"
         self.cfg = kwargs.pop("cfg")
@@ -282,6 +338,9 @@ class vLLMRolloutActor:
         self._top_k = self.cfg.top_k
         self.batch_size = self.cfg.vllm.batch_size
         self._steps_before_sync = self.cfg.steps_before_sync * self.cfg.num_fsdp_workers
+
+        self.actor_id = kwargs.pop("actor_id", 0)
+        self._is_actor_zero = self.actor_id == 0
 
         self.replay_buffer = kwargs.pop("queue")
         self.llm = LLM(*args, **kwargs)
@@ -307,7 +366,18 @@ class vLLMRolloutActor:
         # FIXME: Should really use a lock
         self.sleeping = False
 
-    def start_weight_update(self, param_list):
+        # Initialize policy version for tracking trajectory age
+        self.policy_version = 0
+
+        self.metric_logger = None  # Placeholder for the logger
+
+    def set_metric_logger(self, logger):
+        """Store the MetricLoggerActor handle."""
+        self._metric_logger = logger
+
+    def start_weight_update(self, param_list, policy_version):
+        # Update the policy version when weights are synchronized
+        self.policy_version = policy_version
         for name, dtype, shape in param_list:
             self.llm.collective_rpc("update_weight", args=(name, dtype, shape))
 
@@ -429,7 +499,10 @@ class vLLMRolloutActor:
             logprobs = torch.tensor(logprobs, dtype=torch.float, device="cuda")
 
             query_responses = torch.empty(
-                bs, len(prompt_tokens) + max_seq_len, dtype=torch.long, device="cuda"
+                bs,
+                len(prompt_tokens) + max_seq_len,
+                dtype=torch.long,
+                device="cuda",
             )
             query_responses[:, : len(prompt_tokens)] = torch.tensor(
                 prompt_tokens, dtype=torch.long
@@ -457,6 +530,8 @@ class vLLMRolloutActor:
             ]
 
         for idx, batch in enumerate(self._dataloader):
+            time_step_start = time.perf_counter()
+
             print(f"batch {idx}")
             # might want to do so for 0 also if weights are directly broadcasted from dp?
             if idx != 0 and idx % self._steps_before_sync == 0:
@@ -483,6 +558,11 @@ class vLLMRolloutActor:
             batch_tokens = batch_tokens.reshape(self.batch_size * self.grpo_samples, -1)
             # A downside is they only seem to take in List[List[int]] and not torch.Tensor :(
             batch_tokens = batch_tokens.numpy().tolist()
+
+            # Reset GPU memory stats before generation
+            torch.cuda.reset_peak_memory_stats(device="cuda:0")
+
+            time_generate_start = time.perf_counter()
             # do the generation
             result = self.llm.generate(
                 prompts=None,
@@ -490,8 +570,28 @@ class vLLMRolloutActor:
                 sampling_params=sampling_params,
                 use_tqdm=False,
             )
+            time_generate = time.perf_counter() - time_generate_start
+
+            # Capture peak GPU memory usage
+            gpu_memory_peak_allocated = torch.cuda.max_memory_allocated(device="cuda:0")
+            gpu_memory_peak_reserved = torch.cuda.max_memory_reserved(device="cuda:0")
+
             postprocessed_results = postprocess_vllm_request_output(result)
+
+            # Unpack to compute padded tokens percentage and tokens per second
+            (
+                query_responses,
+                responses,
+                logprobs,
+                query_response_padding_masks,
+                seq_lens,
+            ) = postprocessed_results
+            # Compute total generated tokens for tokens per second
+            total_generated_tokens = seq_lens.sum().item()
+
             postprocessed_results.append(answers)
+            postprocessed_results.append(self.policy_version)
+
             # print(self._tokenizer.decode(batch_tokens[0]))
             # print("===")
             # print(self._tokenizer.decode(postprocessed_results[0][0].cpu().numpy().tolist()))
@@ -502,7 +602,8 @@ class vLLMRolloutActor:
                 for tensor in postprocessed_results
             ]
 
-            # Update circular queue
+            # Update circular queue and count full queue tries
+            full_queue_retries = 0
             while True:
                 try:
                     print(
@@ -512,7 +613,38 @@ class vLLMRolloutActor:
                     break
                 except QueueFull:
                     self.replay_buffer.get()  # Remove the oldest item to make space
+                    full_queue_retries += 1
                     print(f"vLLM queue size after get: {self.replay_buffer.qsize()}")
+
+            # End timing the rollout step
+            time_total_rollout = time.perf_counter() - time_step_start
+
+            # Compute additional metrics
+            pct_time_computing = (
+                (time_generate / time_total_rollout) * 100
+                if time_total_rollout > 0
+                else 0
+            )
+            tokens_per_second = (
+                total_generated_tokens / time_generate if time_generate > 0 else 0
+            )
+
+            # Prepare metrics dictionary
+            div_GiB = 1024**3
+            log_dict = {
+                "vllm_actor_performance/total_rollout_time (s)": time_total_rollout,
+                "vllm_actor_performance/pct_time_computing (%)": pct_time_computing,
+                "vllm_actor_performance/tokens_per_second": tokens_per_second,
+                "vllm_actor_performance/gpu_memory_peak_allocated (GiB)": gpu_memory_peak_allocated
+                / div_GiB,
+                "vllm_actor_performance/gpu_memory_peak_reserved (GiB)": gpu_memory_peak_reserved
+                / div_GiB,
+                "queues/vllm_full_queue_data_discard": full_queue_retries,
+                "queues/rollout_replay_buffer_size": self.replay_buffer.qsize(),
+            }
+
+            # Log metrics using the metric logger
+            ray.get(self._metric_logger.log_dict.remote(log_dict, step=idx))
 
 
 class vLLMWorkerWrapper(Worker):
@@ -553,7 +685,12 @@ class vLLMWorkerWrapper(Worker):
 
 @ray.remote(num_cpus=8, num_gpus=1)
 class PyTorchActorModel:
-    def __init__(self, cfg, environment_variables, replay_buffer):
+    def __init__(
+        self,
+        cfg,
+        environment_variables,
+        replay_buffer,
+    ):
         # shared queue to get trajectories + logprobs from vllm
         self.replay_buffer = replay_buffer
 
@@ -705,10 +842,6 @@ class PyTorchActorModel:
         #     num_training_steps=self.total_epochs * self._steps_per_epoch,
         #     last_epoch=self.global_step - 1,
         # )
-
-        if self._is_rank_zero:
-            self._metric_logger = config.instantiate(cfg.metric_logger)
-
         self._log_peak_memory_stats = cfg.get("log_peak_memory_stats", False)
 
         # Set up profiler, returns DummyProfiler (nullcontext object with no-op `step` method)
@@ -717,7 +850,15 @@ class PyTorchActorModel:
 
         self._steps_before_sync = cfg.steps_before_sync
 
+        # Initialize policy version for tracking age of trajectories
+        self.policy_version = 0
+        self.metric_logger = None  # Placeholder for the logger
+
         print("done setup")
+
+    def set_metric_logger(self, logger):
+        """Store the MetricLoggerActor handle."""
+        self._metric_logger = logger
 
     def _setup_profiler(
         self, cfg_profiler: Optional[DictConfig] = None
@@ -823,35 +964,93 @@ class PyTorchActorModel:
             ) from e
 
     def log_metrics(
-        self, trajectory: GRPOTrajectory, grpo_stats: GRPOStats, **extras
+        self,
+        trajectory: GRPOTrajectory,
+        grpo_stats: GRPOStats,
+        performance_metrics: Optional[Dict[str, float]] = None,
+        **extras,
     ) -> None:
         """
         Log metrics and statistics for the current step to the metric logger.
         """
-        rewards = trajectory.rewards.mean()
-        torch.distributed.reduce(rewards, dst=0, op=torch.distributed.ReduceOp.AVG)
+        if performance_metrics is None:
+            performance_metrics = {}
 
-        successes = trajectory.successes.mean()
-        torch.distributed.reduce(successes, dst=0, op=torch.distributed.ReduceOp.AVG)
+        # Existing reductions for overall metrics
+        rewards_mean = trajectory.rewards.mean()
+        success_rate = trajectory.successes.mean()
+        torch.distributed.reduce(rewards_mean, dst=0, op=torch.distributed.ReduceOp.AVG)
+        torch.distributed.reduce(success_rate, dst=0, op=torch.distributed.ReduceOp.AVG)
 
         log_dict = {
-            "rewards": rewards,
-            "successes": successes,
-            "num_stop_tokens": trajectory.response_padding_masks.any(-1).sum(),
-            "loss": grpo_stats.loss.mean(),
-            "policy_loss": grpo_stats.policy_loss.mean(),
-            "kl_loss": grpo_stats.kl_loss.mean(),
-            "clipfrac": grpo_stats.clipfrac.mean(),
-            "ratios": grpo_stats.ratios.mean(),
-            "approx_policy_kl": grpo_stats.approx_policy_kls.mean(),
-            "response_lengths": trajectory.seq_lens.float().mean(),
-            **extras,
+            # Core training accuracy metrics
+            "train_actor_training/loss": grpo_stats.loss.mean().item(),
+            "train_actor_training/policy_loss": grpo_stats.policy_loss.mean().item(),
+            "train_actor_training/num_stop_tokens": trajectory.response_padding_masks.any(
+                -1
+            )
+            .sum()
+            .item(),  # Verify this is stop tokens, not padding
+            "train_actor_training/kl_loss": grpo_stats.kl_loss.mean().item(),
+            "train_actor_rewards/rewards_mean": rewards_mean.item(),
+            "train_actor_rewards/success_rate": success_rate.item(),
+            "train_actor_training/ratios": grpo_stats.ratios.mean().item(),
+            "train_actor_training/clipfrac": grpo_stats.clipfrac.mean().item(),
+            "train_actor_training/approx_policy_kls": grpo_stats.approx_policy_kls.mean().item(),
+            "train_actor_training/response_lengths": trajectory.seq_lens.float()
+            .mean()
+            .item(),
         }
 
-        if self._device.type == "cuda" and self._log_peak_memory_stats:
-            log_dict.update(training.get_memory_stats(device=self._device))
+        # Collect per-function means into a single tensor
+        mean_reward_per_func = extras.get("mean_reward_per_func", {})
+        mean_success_per_func = extras.get("mean_success_per_func", {})
+
+        # Get function names to preserve order
+        reward_func_names = list(mean_reward_per_func.keys())
+        success_func_names = list(mean_success_per_func.keys())
+
+        # Stack all local means into one tensor
+        all_local_means = [mean_reward_per_func[func] for func in reward_func_names] + [
+            mean_success_per_func[func] for func in success_func_names
+        ]
+        if all_local_means:  # Ensure there's at least one function
+            all_means_tensor = torch.tensor(all_local_means, device=self._device)
+            # Perform a single reduction across ranks
+            torch.distributed.reduce(
+                all_means_tensor, dst=0, op=torch.distributed.ReduceOp.AVG
+            )
+
+            if self._is_rank_zero:
+                # Split the reduced tensor back into rewards and successes
+                num_reward_funcs = len(reward_func_names)
+                global_means = all_means_tensor.tolist()
+                global_reward_means = global_means[:num_reward_funcs]
+                global_success_means = global_means[num_reward_funcs:]
+
+                # Log per-function reward means
+                for func, global_mean in zip(reward_func_names, global_reward_means):
+                    log_dict[f"train_actor_rewards/rewards_{func}_mean"] = global_mean
+                # Log per-function success means
+                for func, global_mean in zip(success_func_names, global_success_means):
+                    log_dict[f"train_actor_rewards/success_{func}_mean"] = global_mean
+
+        # Add performance and queue metrics
+        log_dict.update(
+            {f"train_actor_performance/{k}": v for k, v in performance_metrics.items()}
+        )
+        log_dict["queues/train_actor_policy_age_mean"] = extras.get(
+            "train_actor_policy_age_mean", 0
+        )
+        log_dict["queues/train_actor_replay_buffer_size"] = extras.get(
+            "actor_replay_buffer_size", 0
+        )
+
+        # Log only on rank 0
         if self._is_rank_zero:
-            self._metric_logger.log_dict(log_dict, step=self.global_step)
+            ray.get(
+                self._metric_logger.log_dict.remote(log_dict, step=self.global_step)
+            )
 
     def _setup_model(
         self,
@@ -1119,9 +1318,12 @@ class PyTorchActorModel:
         for curr_epoch in range(1):
             print("starting")
 
-            # need way to coordinate when dataloader is done with an epoch between vllm worker and actor
             dataloader_done = False
             while not dataloader_done:
+                time_step_start = time.perf_counter()
+
+                # Measure time waiting for buffer
+                time_wait_buffer_start = time.perf_counter()
                 trajectory = None
                 while trajectory is None:
                     try:
@@ -1142,6 +1344,7 @@ class PyTorchActorModel:
                     except Exception:
                         trajectory = None
                         time.sleep(0.1)
+                time_wait_buffer = time.perf_counter() - time_wait_buffer_start
 
                 print(f"{self.rank=} got from queue")
 
@@ -1172,20 +1375,30 @@ class PyTorchActorModel:
                     responses,
                     logprobs,
                     ref_logprobs,
-                    # response_padding_masks,
                     query_response_padding_masks,
                     seq_lens,
                     answers,
+                    policy_version,
                 ) = trajectory
 
+                # Compute padded tokens percentage
+                total_tokens = query_responses.numel()
+                padded_tokens = (query_responses == self._tokenizer.pad_id).sum().item()
+                padded_tokens_percentage = (
+                    (padded_tokens / total_tokens) * 100 if total_tokens > 0 else 0
+                )
+                number_of_tokens = seq_lens.sum().item()
+
+                # Reset peak memory stats before GRPO steps
+                torch.cuda.reset_peak_memory_stats()
+
                 # FIXME: move stop token tensor to __init__
-                (
-                    response_padding_masks,
-                    responses,
-                ) = rlhf.truncate_sequence_at_first_stop_token(  # [B x G, L]
-                    responses,
-                    torch.tensor(self._tokenizer.stop_tokens, device=self._device),
-                    self._tokenizer.pad_id,
+                response_padding_masks, responses = (
+                    rlhf.truncate_sequence_at_first_stop_token(  # [B x G, L]
+                        responses,
+                        torch.tensor(self._tokenizer.stop_tokens, device=self._device),
+                        self._tokenizer.pad_id,
+                    )
                 )
 
                 masks = generation.get_causal_mask_from_padding_mask(
@@ -1199,11 +1412,11 @@ class PyTorchActorModel:
                 context_length = query_responses.shape[1] - responses.shape[1]
 
                 responses = responses.reshape(batch_size, grpo_size, -1)
-                rewards, successes = batched_rewards(
+                rewards_dict, successes_dict = batched_rewards(
                     self._tokenizer, responses, answers
                 )
-                rewards = rewards.to(self._device)
-                successes = successes.to(self._device)
+                rewards = rewards_dict["reward_tensor"].to(self._device)
+                successes = successes_dict["success_tensor"].to(self._device)
 
                 advantages = (rewards - rewards.mean(1, keepdim=True)) / (
                     rewards.std(1, keepdim=True) + 1e-4
@@ -1229,9 +1442,13 @@ class PyTorchActorModel:
 
                 torch.distributed.barrier()
 
+                # Measure compute time across all GRPO steps
+                total_compute_time = 0
                 grpo_stats: list[GRPOStats] = []
                 for _ in range(self._ppo_epochs):
+                    compute_start = time.perf_counter()
                     step_stats = self.grpo_step(trajectory, context_length)
+                    total_compute_time += time.perf_counter() - compute_start
 
                     grpo_stats.append(step_stats)
 
@@ -1254,30 +1471,72 @@ class PyTorchActorModel:
 
                 self._steps_run += 1
 
+                # Get peak memory stats after GRPO steps
+                gpu_memory_peak_allocated = torch.cuda.max_memory_allocated()
+                gpu_memory_peak_reserved = torch.cuda.max_memory_reserved()
+
+                # Compute policy age
+                policy_age = self.policy_version - policy_version
+
+                # Handle weight synchronization
+                time_weight_sync = 0
+                time_weight_gather = 0
                 if self._steps_run % self._steps_before_sync == 0:
                     torch.distributed.barrier()
-                    start = time.time()
+                    time_sync_start = time.perf_counter()
                     print("started weight sync")
+
                     # gather all parameters
                     new_sd = {}
-                    start_gather = time.time()
                     for k, v in self._model.state_dict().items():
                         new_sd[k] = v.full_tensor()
                     torch.cuda.synchronize()
+                    time_weight_gather = time.perf_counter() - time_sync_start
                     if self._is_rank_zero:
-                        print(f"done gather in {time.time() - start_gather}")
-
+                        print(f"Done gather in {time_weight_gather}")
                     self.sync_weights(new_sd)
                     del new_sd
+                    time_weight_sync = time.perf_counter() - time_sync_start
 
-                    if self._is_rank_zero:
-                        self._vllm_engines[0].wake_up.remote()
-                        print(f"ended weight sync in {time.time()-start}")
+                # Compute total step time
+                total_step_time = time.perf_counter() - time_step_start
+                # Calculate conversion factor for bytes to GiB
+                bytes_to_gib = 1024**3
 
-                extra_metrics = {}
+                # Compile performance metrics
+                performance_metrics = {
+                    "total_step_time (s)": total_step_time,
+                    "pct_time_computing (%)": (
+                        (total_compute_time / total_step_time) * 100
+                        if total_step_time > 0
+                        else 0
+                    ),
+                    "tokens_per_second": (
+                        number_of_tokens / total_step_time if total_step_time > 0 else 0
+                    ),
+                    "gpu_memory_peak_allocated (GiB)": gpu_memory_peak_allocated
+                    / bytes_to_gib,
+                    "gpu_memory_peak_reserved (GiB)": gpu_memory_peak_reserved
+                    / bytes_to_gib,
+                    "time_weight_sync (s)": time_weight_sync,
+                    "padded_tokens_percentage (%)": padded_tokens_percentage,
+                    "time_wait_buffer (s)": time_wait_buffer,
+                    "time_weight_gather (s)": time_weight_gather,
+                }
+
+                # Compile extra metrics
+                extra_metrics = {
+                    "train_actor_policy_age_mean": policy_age,
+                    "actor_replay_buffer_size": self.replay_buffer.qsize(),
+                    "mean_reward_per_func": rewards_dict["mean_reward_per_func"],
+                    "mean_success_per_func": successes_dict["mean_success_per_func"],
+                }
+
+                # Log metrics
                 self.log_metrics(
                     trajectory,
                     GRPOStats(*map(torch.stack, zip(*grpo_stats))),
+                    performance_metrics=performance_metrics,
                     **extra_metrics,
                 )
                 print("done logging")
@@ -1311,6 +1570,9 @@ class PyTorchActorModel:
         self._profiler.stop()
 
     def sync_weights(self, new_sd):
+        # Increment policy version
+        self.policy_version += 1
+
         if self._is_rank_zero:
             # Convert to vLLM-compatible format
             # FIXME: don't hardcode kwargs here
@@ -1320,7 +1582,8 @@ class PyTorchActorModel:
 
             # Start weight update on vLLM workers (non-blocking)
             vllm_update_refs = [
-                eng.start_weight_update.remote(param_list) for eng in self._vllm_engines
+                eng.start_weight_update.remote(param_list, self.policy_version)
+                for eng in self._vllm_engines
             ]
 
             # Broadcast each parameter to vLLM workers
@@ -1339,13 +1602,26 @@ class PyTorchActorModel:
             # Non-zero training ranks don’t participate in vLLM weight sync
             pass
 
-        # Cleanup
         torch.distributed.barrier()
         print("waking up", flush=True)
 
     def cleanup(self) -> None:
         if self._is_rank_zero:
             self._metric_logger.close()
+
+
+@ray.remote(num_cpus=1, num_gpus=0)
+class MetricLoggerActor:
+    def __init__(self, cfg):
+        self.logger = config.instantiate(cfg.metric_logger)
+
+    def log_dict(self, log_dict, step=None):
+        # allowing actors to use their own step counters
+        self.logger.log_dict(log_dict, step=step)
+
+    def close(self):
+        if hasattr(self.logger, "close"):
+            self.logger.close()
 
 
 class RayGRPORecipe:
@@ -1376,6 +1652,10 @@ class RayGRPORecipe:
         )
         self._init_weight_sync_pg()
 
+        # needs to happens after workers are created
+        # or there are conflicts with the placement group
+        self._set_metric_logger_to_actors()
+
     def start_ray(self):
         total_gpus = (
             self.num_vllm_workers * self.vllm_tp_size
@@ -1383,10 +1663,18 @@ class RayGRPORecipe:
             + self.num_fsdp_workers
         )
         total_cpus = 32 * total_gpus + 2
-        ray.init(
-            num_cpus=total_cpus, num_gpus=total_gpus
-        )  # Set to 8 if you have 8 GPUs
-        print(ray.cluster_resources())
+        ray.init(num_cpus=total_cpus, num_gpus=total_gpus)
+        print("Cluster resources:", ray.cluster_resources())
+
+    def _set_metric_logger_to_actors(self):
+        self.metric_logger = MetricLoggerActor.remote(self.cfg)
+        # Pass the logger handle to each worker
+        for worker in self.rollout_workers:
+            worker.set_metric_logger.remote(self.metric_logger)
+        for worker in self.ref_workers:
+            worker.set_metric_logger.remote(self.metric_logger)
+        for worker in self.actor_workers:
+            worker.set_metric_logger.remote(self.metric_logger)
 
     def _create_fsdp_group(self, worker_cls, fsdp_world_size: int):
         addr, port = get_ip(), get_open_port()
@@ -1398,7 +1686,11 @@ class RayGRPORecipe:
                 "MASTER_ADDR": addr,
                 "MASTER_PORT": port,
             }
-            worker = worker_cls.remote(self.cfg, env_vars, self.actor_replay_buffer)
+            worker = worker_cls.remote(
+                self.cfg,
+                env_vars,
+                self.actor_replay_buffer,
+            )
             fsdp_workers.append(worker)
         return fsdp_workers
 
@@ -1416,6 +1708,9 @@ class RayGRPORecipe:
             # Define placement group for this worker
             pg_inference = placement_group([{"GPU": 1, "CPU": 10}] * self.vllm_tp_size)
             ray.get(pg_inference.ready())
+            print(
+                f"Placement group for vLLM worker {i} ready with {self.vllm_tp_size} GPUs"
+            )
             scheduling_inference = PlacementGroupSchedulingStrategy(
                 placement_group=pg_inference,
                 placement_group_capture_child_tasks=True,
@@ -1439,6 +1734,7 @@ class RayGRPORecipe:
                     distributed_executor_backend="ray",
                     queue=self.rollout_replay_buffer,
                     cfg=self.cfg,
+                    actor_id=i,
                 )
             )
             llms.append(llm)
@@ -1451,6 +1747,7 @@ class RayGRPORecipe:
                 rollout_queue=self.rollout_replay_buffer,
                 actor_queue=self.actor_replay_buffer,
                 cfg=self.cfg,
+                actor_id=i,
             )
             workers.append(worker)
         return workers

--- a/torchtune/dev/grpo/types.py
+++ b/torchtune/dev/grpo/types.py
@@ -7,6 +7,7 @@
 from typing import NamedTuple
 
 import torch
+
 # from tensordict.tensorclass import TensorClass
 
 
@@ -18,8 +19,6 @@ class GRPOTrajectory(NamedTuple):
         query_responses (torch.Tensor): (query, response) pairs with shape [B x G, P+L].
         logprobs (torch.Tensor): Log probabilities of the generated responses with shape [B x G, L].
         ref_logprobs (torch.Tensor): Log probabilities of the generated responses using the reference policy with shape [B x G, L].
-        rewards (torch.Tensor): Rewards obtained from the environment or reward model with shape [B x G].
-        successes (torch.Tensor): Success indicators for each trajectory.
         advantages (torch.Tensor): Advantage estimates for the generated responses with shape [B x G].
         masks (torch.Tensor): Attention masks for input ids-generated responses pairs with shape [B x G, P+L, P+L].
         position_ids (torch.Tensor): Position IDs for input ids-generated responses pairs with shape [B x G, P+L].
@@ -30,8 +29,6 @@ class GRPOTrajectory(NamedTuple):
     query_responses: torch.Tensor = None  # [B x G, P+L]
     logprobs: torch.Tensor = None  # [B x G, L]
     ref_logprobs: torch.Tensor = None  # [B x G, L]
-    rewards: torch.Tensor = None  # [B x G]
-    successes: torch.Tensor = None
     advantages: torch.Tensor = None  # [B x G]
     masks: torch.Tensor = None  # [B x G, P+L, P+L]
     position_ids: torch.Tensor = None  # [B x G, P+L]


### PR DESCRIPTION
TLDR: Added metrics to all actors that should aid with improving performance and model quality.

![image](https://github.com/user-attachments/assets/b365ecd6-ed07-4e0d-b065-882d79bfd367)

----> [CLICK HERE] <-----
Example of wandb output: https://api.wandb.ai/links/fmello/obisun9u

-----
Examples of cool stuff you can do:

1) Your training is spending a lof of time waiting for the buffer to fill
<img width="375" alt="image" src="https://github.com/user-attachments/assets/9ba956b8-93e9-4272-908a-3a999c49ea85" />

2) Your vLLM waste 23 of its time iddle (prob waiting for weight sync)
<img width="446" alt="image" src="https://github.com/user-attachments/assets/e1cd62bc-aca7-4997-94a5-0d9bf88317af" />

3) Rewards are growing, but some of them have zero success
<img width="1165" alt="image" src="https://github.com/user-attachments/assets/a9be6cfd-e6f3-4477-a7b3-9d41efe84be0" />

4) Your training data is usually 1 policy behind
<img width="394" alt="image" src="https://github.com/user-attachments/assets/15b0c670-8859-4f34-8835-a0d5a9d71ffe" />

5) Since your queues are empty most of the time, (producer < consumer) you are not discarding data
<img width="775" alt="image" src="https://github.com/user-attachments/assets/69a80de8-dbcc-4c02-bf99-5316ebb0e54c" />

----
How:
- Instantiate single metric logger worker in GRPOActor
- Set the logger in all other workers
- Log only on rank 0 (pytorch actor) or actor_id=0 (vllm / ref actors)

Where:
- All classes have a log_metrics method

What:
## RefActor
- **Performance Metrics:**
  - `ref_actor_performance/time_total_ref_step (s)`: Total time taken for the reference actor step.
  - `ref_actor_performance/time_model_running (s)`: Time spent executing the model.
  - `ref_actor_performance/pct_time_model_running (%)`: Percentage of step time spent running the model.
  - `ref_actor_performance/time_waiting_buffer (s)`: Time spent waiting for data from the buffer.
  - `ref_actor_performance/pct_time_waiting_buffer (%)`: Percentage of step time spent waiting for the buffer.
- **Queue Metrics:**
  - `queues/ref_actor_full_queue_data_discard`: Number of times data was discarded due to a full queue.
  - `queues/rollout_replay_buffer_size`: Current number of items in the rollout replay buffer.
- **Memory Metrics (if `log_peak_memory_stats` is True):**
  - `ref_actor_performance/memory/allocated`: Amount of memory allocated on the GPU.
  - `ref_actor_performance/memory/reserved`: Amount of memory reserved on the GPU.
  - `ref_actor_performance/memory/active`: Amount of active memory used on the GPU.

## vLLMRolloutActor
- **Performance Metrics:**
  - `vllm_actor_performance/total_rollout_time (s)`: Total time taken for the rollout step.
  - `vllm_actor_performance/pct_time_model_running (%)`: Percentage of rollout time spent running the model.
  - `vllm_actor_performance/tokens_per_second`: Number of tokens generated per second.
- **Memory Metrics:**
  - `vllm_actor_performance/gpu_memory_peak_allocated (GiB)`: Peak GPU memory allocated during the step.
  - `vllm_actor_performance/gpu_memory_peak_reserved (GiB)`: Peak GPU memory reserved during the step.
  - `vllm_actor_performance/gpu_memory_peak_active (GiB)`: Peak active GPU memory during the step.
- **Queue Metrics:**
  - `queues/vllm_full_queue_data_discard`: Number of times data was discarded due to a full queue.
  - `queues/rollout_replay_buffer_size`: Current number of items in the rollout replay buffer.

## PyTorchActorModel
- **Training Metrics:**
  - `train_actor_training/loss`: Average total loss across the training step.
  - `train_actor_training/policy_loss`: Average policy-specific loss.
  - `train_actor_training/num_stop_tokens`: Number of stop tokens encountered in responses.
  - `train_actor_training/kl_loss`: Average KL divergence loss.
  - `train_actor_training/ratios`: Average ratio of current to old policy probabilities.
  - `train_actor_training/clipfrac`: Average fraction of ratios clipped during optimization.
  - `train_actor_training/approx_policy_kls`: Average approximate KL divergence between policies.
  - `train_actor_training/response_lengths`: Average length of generated responses.
- **Rewards and Successes:**
  - `train_actor__rewards/rewards_mean`: Mean reward value across the batch.
  - `train_actor__rewards/successes_mean`: Mean success rate across the batch.
  - `train_actor__rewards/rewards_func_{func_name}_mean`: Mean reward for a specific function (per function in `reward_metadata`).
  - `train_actor_rewards/successes_func_{func_name}_mean`: Mean success rate for a specific function (per function in `reward_metadata`).
- **Performance Metrics:**
  - `train_actor_performance/total_step_time (s)`: Total time taken for the training step.
  - `train_actor_performance/time_grpo_steps (s)`: Time spent on GRPO optimization steps.
  - `train_actor_performance/pct_time_grpo_steps (%)`: Percentage of step time spent on GRPO steps.
  - `train_actor_performance/tokens_per_second`: Number of tokens processed per second.
  - `train_actor_performance/time_weight_sync (s)`: Time spent synchronizing weights.
  - `train_actor_performance/pct_time_weight_sync (%)`: Percentage of step time spent on weight synchronization.
  - `train_actor_performance/padded_tokens_percentage (%)`: Percentage of tokens that are padding.
  - `train_actor_performance/time_waiting_buffer (s)`: Time spent waiting for data from the buffer.
  - `train_actor_performance/pct_time_waiting_buffer (%)`: Percentage of step time spent waiting for the buffer.
  - `train_actor_performance/time_weight_gather (s)`: Time spent gathering weights across ranks.
  - `train_actor_performance/pct_time_weight_gather (%)`: Percentage of step time spent gathering weights.
- **Queue Metrics:**
  - `queues/train_actor_policy_age_mean`: Average age of the policy relative to trajectories.
  - `queues/train_actor_replay_buffer_size`: Current number of items in the training replay buffer.
- **Memory Metrics (if `log_peak_memory_stats` is True):**
  - `train_actor_performance/memory/allocated`: Amount of memory allocated on the GPU.
  - `train_actor_performance/memory/reserved`: Amount of memory reserved on the GPU.
  - `train_actor_performance/memory/active`: Amount of active memory used on the GPU.
