### PR TITLE
[PoC] Use RayCollector + weight update extension points with super v0 "param server"

### DIFF
--- a/recipes/configs/dev/qwen3B_full_grpo.yaml
+++ b/recipes/configs/dev/qwen3B_full_grpo.yaml
@@ -114,7 +114,7 @@ num_ref_workers: 1
 num_fsdp_workers: 2
 
 vllm:
-  num_workers: 5
+  num_workers: 4
   tp_size: 1
   batch_size: 1 # TODO: for now, needs to match recipe batch size
   queue_maxsize: 3 #num workers * steps_before_sync

--- a/recipes/configs/dev/qwen3B_full_grpo.yaml
+++ b/recipes/configs/dev/qwen3B_full_grpo.yaml
@@ -118,6 +118,7 @@ vllm:
   tp_size: 1
   batch_size: 1 # TODO: for now, needs to match recipe batch size
   queue_maxsize: 3 #num workers * steps_before_sync
+  gpu_memory_utilization: 0.7
 
 
 # Logging

--- a/recipes/configs/dev/qwen3B_full_grpo.yaml
+++ b/recipes/configs/dev/qwen3B_full_grpo.yaml
@@ -117,7 +117,7 @@ vllm:
   num_workers: 4
   tp_size: 1
   batch_size: 1 # TODO: for now, needs to match recipe batch size
-  queue_maxsize: 3 #num workers * steps_before_sync
+  queue_maxsize: 3
   gpu_memory_utilization: 0.7
 
 

--- a/scripts/runnable_recipe_ray_vllm_weight_sync.py
+++ b/scripts/runnable_recipe_ray_vllm_weight_sync.py
@@ -1597,11 +1597,7 @@ class RayGRPORecipe:
             actor_options={"num_cpus": 10, "num_gpus": 0},
             maxsize=cfg.vllm.queue_maxsize,
         )
-        self.replay_buffer = RayReplayBuffer(
-            storage=functools.partial(LazyStackStorage, max_size=3),
-            batch_size=1,
-            remote_config={"num_cpus": 10, "num_gpus": 0},
-        )
+        self.replay_buffer = RayReplayBuffer(storage=functools.partial(LazyStackStorage, max_size=self.cfg.vllm.queue_maxsize), batch_size=1, remote_config={"num_cpus": 10, "num_gpus": 0})
 
         # Create workers using config values directly
         self.rollout_workers = self._create_vllm_workers()

--- a/scripts/runnable_recipe_ray_vllm_weight_sync.py
+++ b/scripts/runnable_recipe_ray_vllm_weight_sync.py
@@ -698,12 +698,6 @@ class PyTorchActorModel:
         # Initialize policy version for tracking age of trajectories
         self.policy_version = 0
         self.metric_logger = None  # Placeholder for the logger
-        
-        t = torch.tensor([1], device='cuda')
-        if self._is_rank_zero:
-            print("doing send")
-            torch.distributed.send(t, dst=2)
-            print("done send")
 
         log.info("Done setup")
 

--- a/torchtune/dev/grpo/data.py
+++ b/torchtune/dev/grpo/data.py
@@ -71,11 +71,13 @@ class RLDataset(Dataset):
 
         question = BASE_PROMPT % transformed_sample["question"]
 
-        q_tokens = self._tokenizer.encode(question, add_eos=False)
-        mask = [1 for _ in q_tokens]
+        # q_tokens = self._tokenizer.encode(question, add_eos=False)
+        # mask = [1 for _ in q_tokens]
         answer = transformed_sample["answer"]
+    
+        return {"question": question, "answer": answer}
 
-        return {"tokens": q_tokens, "mask": mask, "answer": answer}
+        # return {"tokens": q_tokens, "mask": mask, "answer": answer}
 
 
 def padded_collate_rl(


### PR DESCRIPTION
The main goal of this PoC is to 
(1) demonstrate integration of RayCollector
(2) Provide example of using weight sync extension points in RayCollector and ensure it works end to end

I have basically not thought about perf and efficient weight sync strategies yet :(


This PR depends on https://github.com/pytorch/rl/pull/2865/files which contains the bulk of the weight sync logic. (That PR is not rebased onto torchrl main yet),
(1) torchrl main deleted `from_vllm` and now uses `vLLMWrapper`
(2) when rebasing and moving to vLLMWrapper I see issues with lazy_stack that I haven't looked into 😢 


Rewards/Successes
<img width="1404" alt="Screenshot 2025-03-28 at 10 03 28 AM" src="https://github.com/user-attachments/assets/67d55035-8d7e-47a4-a003-656db9dc80eb" />

Policy age:
<img width="469" alt="Screenshot 2025-03-28 at 10 16 43 AM" src="https://github.com/user-attachments/assets/a7be99db-492b-41d5-960d-d34f1035f43b" />


## Weight sync
How does the weight sync change in this PR?

On `main` 
- After `steps_before_sync` steps all `vLLMRolloutActor`s will spin and wait for the trainer to update their weights
- After `steps_before_sync` steps, trainer will all gather to rank 0 and broadcast to *ALL* vLLM workers then notify them to continue rollouts


In this PR:
- there is an extra rank in the global process group for the trainer that subclasses `RemoteWeightUpdaterBase` and I call a v0 "param server"
- every `steps_before_sync` steps, trainer workers all gather and rank0 broadcasts to that last rank
- RayCollector utilizes [`_async_iterator`](https://github.com/pytorch/rl/blob/e1d3fd488d48d68999782df4dc58925e40943642/torchrl/collectors/distributed/ray.py#L735) which get a batch from one of the remote collectors (vLLM policy + LLMEnv that contains the dataloader) and afterwards because `update_after_each_batch=True` will try to update weights of that specific remote collector. The "param server" tracks versioning and will only broadcast weights to the vLLM if it has a newer version

An implication is that the broadcast happens 1 param server to 1 worker at a time in this PR. But that is largely due to how `async_iterator` works and will be changed



## Things that are broken
(1) tp_size > 1 (need to modify design to make Remote and Local Weight Updaters aware of each other and able to communicate, or alternatively pass in tp_size to RemoteWeightUpdater at __init__)
(2) logging in vLLMRollout Actors
(3) Tokenizer is changed to hf tokenizer 
(4) I think batch_size > 1  (not grpo_samples) might be broken




## Next Steps

- Make remote collectors responsible for updating themselves rather than update being orchestrated by RayCollector
- Actually make weight sync efficient, consider and prototype different strategies for syncing the weights, resharding etc. Not just rely on vLLM `update_weights` to do sharding
