### PR TITLE
Introduce OmegaConf interpolation

### DIFF
--- a/recipes/configs/dev/qwen3B_full_grpo.yaml
+++ b/recipes/configs/dev/qwen3B_full_grpo.yaml
@@ -21,6 +21,7 @@
 #  sbatch multinode_grpo.sbatch
 
 name: grpo_qwen3b
+total_inference_batch_size: ${eval:'${vllm.batch_size} * ${grpo_samples}'}
 
 output_dir: /tmp/checkpoints/${name}
 base_model_path: /tmp/Qwen2.5-3B  # Use this to train from the slightly trained SFT model
@@ -76,7 +77,7 @@ grpo_samples: 16
 max_generated_tokens: 512
 top_k: null
 temperature: 1.0
-replay_buffer_size: 64
+replay_buffer_size: ${total_inference_batch_size}  # TODO this needs to be fixed. Right now this can't be bigger, or else we'll get padding issues
 
 ppo_epochs: 1
 
@@ -117,7 +118,7 @@ vllm:
   num_workers: 5
   tp_size: 1
   batch_size: 1
-  queue_maxsize: 128 #num workers * steps_before_sync
+  queue_maxsize: ${eval:'${vllm.num_workers} * ${steps_before_sync}'}
 
 
 # Logging


### PR DESCRIPTION
This is a contentious feature.

Pros:
- Allows you to clearly show in config files what a value is going to be
- Reduces manual errors: "you changed batch size, did you remember to change buffer size accordingly?"
- Clear logging: after calling `OmegaConf.resolve()`, every value is resolved to its numerical value and logged in W&B as a number, not as an expression

Cons:
- One potential big con of this is that you open the door for "programming with configs". Variable interpolations are powerful already, and when you allow evals to be there... well, the sky really becomes the limit.

The cons are there, but IMHO the pros far outweigh them. Any experimentation platform benefits from the pros so much that you have to keep the cons at bay by enforcing sanity in the configs (but after you open this door, your customers may not be as disciplined with it)