### PR TITLE
Unbreak with torchrl main

### DIFF
--- a/scripts/runnable_recipe_ray_vllm_weight_sync.py
+++ b/scripts/runnable_recipe_ray_vllm_weight_sync.py
@@ -1536,19 +1536,18 @@ class PyTorchActorModel:
             metadata (dict): Metadata for logging, including rewards and performance metrics.
         """
         # Extract components from raw trajectory
-        # Extract components from raw trajectory
-        query_responses = raw_trajectory["query_responses"]
-        responses = raw_trajectory["responses"]
-        logprobs = raw_trajectory["logprobs"]
-        ref_logprobs = raw_trajectory["ref_logprobs"]
-        query_response_padding_masks = raw_trajectory["query_response_padding_masks"]
-        seq_lens = raw_trajectory["seq_lens"]
-        answers = raw_trajectory["answers"]
-        policy_version = raw_trajectory["policy_version"]
-        rewards = raw_trajectory["rewards"]
-        advantages = raw_trajectory["advantages"]
-        successes = raw_trajectory["successes"]
-        reward_metadata = raw_trajectory["reward_metadata"]
+        query_responses = raw_trajectory.query_responses
+        responses = raw_trajectory.responses
+        logprobs = raw_trajectory.logprobs
+        ref_logprobs = raw_trajectory.ref_logprobs
+        query_response_padding_masks = raw_trajectory.query_response_padding_masks
+        seq_lens = raw_trajectory.seq_lens
+        answers = raw_trajectory.answers
+        policy_version = raw_trajectory.policy_version
+        rewards = raw_trajectory.rewards
+        advantages = raw_trajectory.advantages
+        successes = raw_trajectory.successes
+        reward_metadata = raw_trajectory.reward_metadata
 
         # Compute padded tokens percentage
         total_tokens = query_responses.numel()


### PR DESCRIPTION
Type of `raw_trajectory` sampled from replay_buffer changed from `LazyStackedTensorDict` to `Trajectory` in latest rl `main`

<img width="1213" alt="Screenshot 2025-04-02 at 7 10 39 PM" src="https://github.com/user-attachments/assets/a73cb74e-27b5-4950-a640-e59bdf6e9bec" />
