### PR TITLE
Fix setting vllm tp_size + fix hang with tp weight sync

### DIFF
--- a/scripts/runnable_recipe_ray_vllm_weight_sync.py
+++ b/scripts/runnable_recipe_ray_vllm_weight_sync.py
@@ -996,7 +996,7 @@ class LLMCollector(SyncDataCollector):
 
 class VLLMWorkerWrapper(Worker):
     """
-    vLLM Rollout Model worker for Ray.
+    vLLM worker for Ray.
 
     vLLMParameterServer will always take rank 0 in the stateless process group
     initialized by this worker. And the tp ranks associated with the LLM class

--- a/scripts/runnable_recipe_ray_vllm_weight_sync.py
+++ b/scripts/runnable_recipe_ray_vllm_weight_sync.py
@@ -122,11 +122,10 @@ def stateless_init_process_group(
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
     from vllm.distributed.utils import StatelessProcessGroup
 
-    print(master_address, master_port, rank, world_size, device)
     pg = StatelessProcessGroup.create(
         host=master_address, port=master_port, rank=rank, world_size=world_size
     )
-    print("got pg")
+
     pynccl = PyNcclCommunicator(pg, device=device)
     return pynccl
 
@@ -753,7 +752,7 @@ class LLMCollector(SyncDataCollector):
         self._remote_weight_updater = value
 
     def _postprocess_for_queue(self, data):
-        # local import below LLM call to avoid vLLM no CUDA GPUs available error
+        # local import to avoid vLLM no CUDA GPUs available error
         from torchtune import training
 
         data = data.squeeze()
@@ -803,9 +802,6 @@ class LLMCollector(SyncDataCollector):
         **kwargs,
     ) -> None:
         self.local_weight_updater(policy_weights, **kwargs)
-
-    def llm_collective_rpc(self, *args, **kwargs):
-        self.inference_server.collective_rpc(*args, **kwargs)
 
     def set_metric_logger(self, logger):
         """Store the MetricLoggerActor handle."""
@@ -901,12 +897,6 @@ class LLMCollector(SyncDataCollector):
             assert self.replay_buffer is None
             postprocessed_results, total_generated_tokens = self._postprocess_for_queue(
                 data
-            )
-
-            print(
-                self._tokenizer.decode(
-                    postprocessed_results.query_responses[0].cpu().numpy().tolist()
-                )
             )
 
             while True:

--- a/torchtune/dev/grpo/data.py
+++ b/torchtune/dev/grpo/data.py
@@ -8,12 +8,8 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, TypedDict, Unio
 
 import torch
 from datasets import load_dataset
-
-# from tensordict.nn import TensorDictModule
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import Dataset
-
-# from tensordict import NestedKey
 
 from torchtune.data import CROSS_ENTROPY_IGNORE_IDX
 from torchtune.modules.tokenizers import ModelTokenizer


### PR DESCRIPTION
<img width="1473" alt="Screenshot 2025-04-07 at 3 24 05 PM" src="https://github.com/user-attachments/assets/9bce4bfa-ab58-4862-a5d6-b062bd0496a8" />

Weirdly with larger tp_size I don't really observe generation speed per `LLM` to be higher and as a result policy age is older and it isn't learning as well. I can repro this behavior where with bs=1, grpo_samples=16, tp size 2 does not seem to yield higher tok/s with a minimal repro in [P1778898118](https://www.internalfb.com/phabricator/paste/view/P1778898118)

<img width="783" alt="Screenshot 2025-04-07 at 3 39 59 PM" src="https://github.com/user-attachments/assets/3a67b219-adcb-4fbd-b65e-5c26c8778730" />


<img width="464" alt="Screenshot 2025-04-07 at 3 24 12 PM" src="https://github.com/user-attachments/assets/68b2e6be-d920-4444-bc39-f2135fa8c6d8" />

