### PR TITLE
Fix tag extraction

### DIFF
--- a/torchtune/dev/grpo/rewards.py
+++ b/torchtune/dev/grpo/rewards.py
@@ -18,6 +18,10 @@ from torchtune.modules.transforms.tokenizers import ModelTokenizer
 
 
 def extract_tags(text: str) -> Tuple[str, str]:
+    """
+    Parse XML-like tags from text. Returns a dictionary with keys 'think' and 'answer'.
+    The values are lists of strings, with each string being the content of a tag.
+    """
     think_pattern = r"<think>(.*?)</think>"
     answer_pattern = r"<answer>(.*?)</answer>"
     think_match = re.search(think_pattern, text, re.DOTALL)

--- a/torchtune/dev/grpo/rewards.py
+++ b/torchtune/dev/grpo/rewards.py
@@ -4,11 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import re
 from typing import List, Tuple
 from xml.etree import ElementTree as ET
 
 import torch
-from numpy.ma.core import reshape
 
 # from tensordict import TensorDict, TensorDictBase
 # from torchrl.data import Composite, TensorSpec, Unbounded
@@ -18,20 +18,13 @@ from torchtune.modules.transforms.tokenizers import ModelTokenizer
 
 
 def extract_tags(text: str) -> Tuple[str, str]:
-    """
-    Parse XML-like tags from text. Returns a dictionary with keys 'think' and 'answer'.
-    The values are lists of strings, with each string being the content of a tag.
-    """
-    xml_string = f"<root>{text}</root>"
-    try:
-        root = ET.fromstring(xml_string)
-    except ET.ParseError as e:
-        return ("", "")
-
-    return (
-        root.find("think").text if root.find("think") is not None else "",
-        root.find("answer").text if root.find("answer") is not None else "",
-    )
+    think_pattern = r"<think>(.*?)</think>"
+    answer_pattern = r"<answer>(.*?)</answer>"
+    think_match = re.search(think_pattern, text, re.DOTALL)
+    answer_match = re.search(answer_pattern, text, re.DOTALL)
+    cot = think_match.group(1).strip() if think_match else ""
+    potential_answer = answer_match.group(1).strip() if answer_match else ""
+    return cot, potential_answer
 
 
 def at_least_one_space_between_think_tags(


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Analyze outputs and saw that correct answers were not receiving rewards. So I replaced extract_tags with regex. It was silently not finding anything in between the tags, returning empty strings, making it impossible to find rewards. I imagine that at some point the model figured out how to make the response XML friendly, and thats why we still saw rewards going up.

![image](https://github.com/user-attachments/assets/730a13ad-6e54-4873-b78f-26d3ce6bfa8c)

![image](https://github.com/user-attachments/assets/65834643-3b8d-4f29-a0f0-5fc34b402e9d)


