### PR TITLE
Use math-verify to check answers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 
     # Multimodal
     "Pillow>=9.4.0",
+    "math-verify[antlr4_9_3]"
 ]
 dynamic = ["version"]
 

--- a/torchtune/dev/grpo/rewards.py
+++ b/torchtune/dev/grpo/rewards.py
@@ -16,6 +16,7 @@ import torch
 
 from torchtune.modules.transforms.tokenizers import ModelTokenizer
 
+import math_verify
 
 def extract_tags(text: str) -> Tuple[str, str]:
     """
@@ -47,7 +48,10 @@ def math_response_correct(
     """Did it get the right answer?"""
     if potential_answer is None:
         return 0.0, 0.0  # (reward, success)
-    if answer == potential_answer:
+    gold = math_verify.parse(answer)
+    attempt = math_verify.parse(potential_answer)
+
+    if math_verify.verify(gold, attempt):
         return 100.0, 1.0
     if answer in potential_answer:
         return 50.0, 0.0


### PR DESCRIPTION
Hello and greetings from FAIR, I mentioned using math-verify over in pytorch/torchtune#2604, @felipemello1 mentioned I should put it here, so here it is.

The timing is a bit awkward since I'm on PTO right now, but I treat this as evening OSS hacking since it's not any new code for me - the downside is that I won't be able to join any meetings in the near future to discuss this or other things, unless really necessary. Still, I hope this will be helpful in some form.

The tl;dr of this change is that it's a more flexible correctness checker, like if the reference answer is 42, it will also accept \boxed{42}. I've seen this used in some other GRPO implementations, in my experiments it works great so I switched to it by default. (I don't have any formal benchmarks on hand right now, but there were some buried in my wandb logs)

In my own code, I control this with a config entry going through a `_component_`-style reward verifier, not sure if there's an appropriate place here to make this togglable.