### PR TITLE
Remove weight_update_sender

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,15 @@ repos:
     -   id: end-of-file-fixer
         exclude: '^(.*\.svg)$'
 
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+    -   id: insert-license
+        files: \.py$|\.sh$
+        args:
+        - --license-filepath
+        - docs/license_header.txt
+
 -   repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,15 +17,6 @@ repos:
     -   id: end-of-file-fixer
         exclude: '^(.*\.svg)$'
 
--   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.5
-    hooks:
-    -   id: insert-license
-        files: \.py$|\.sh$
-        args:
-        - --license-filepath
-        - docs/license_header.txt
-
 -   repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:

--- a/recipes/dev/async_grpo_full_finetune_distributed.py
+++ b/recipes/dev/async_grpo_full_finetune_distributed.py
@@ -35,6 +35,7 @@ from torchtune.dev.rl.workers import (
 from torchtune.recipe_interfaces import OrchestrationRecipeInterface
 from vllm import SamplingParams
 
+from vllm import SamplingParams
 from vllm.utils import get_ip, get_open_port
 
 log = utils.get_logger("DEBUG")

--- a/recipes/dev/async_grpo_full_finetune_distributed.py
+++ b/recipes/dev/async_grpo_full_finetune_distributed.py
@@ -358,10 +358,6 @@ class RayGRPORecipe(OrchestrationRecipeInterface):
                     weight_update_receiver=weight_update_receivers[i],
                 )
             )
-            # TODO: Currently we register a handle to the collector to the parameter server
-            # this will be cleaned up when we make the local_weight_updater remotely call
-            # the param server
-            ray.get(self.param_server.register_collector.remote(i, collector))
             data_collectors.append(collector)
         return data_collectors
 

--- a/recipes/dev/async_grpo_full_finetune_distributed.py
+++ b/recipes/dev/async_grpo_full_finetune_distributed.py
@@ -7,6 +7,7 @@
 import functools
 import os
 import time
+
 from typing import Any, Dict
 
 import ray
@@ -35,7 +36,6 @@ from torchtune.dev.rl.workers import (
 from torchtune.recipe_interfaces import OrchestrationRecipeInterface
 from vllm import SamplingParams
 
-from vllm import SamplingParams
 from vllm.utils import get_ip, get_open_port
 
 log = utils.get_logger("DEBUG")

--- a/torchtune/dev/rl/workers/datacollectors/sync.py
+++ b/torchtune/dev/rl/workers/datacollectors/sync.py
@@ -15,7 +15,6 @@ import torch.distributed
 from omegaconf import DictConfig, ListConfig
 
 from ray.util.queue import Full as QueueFull
-
 from tensordict import lazy_stack, NonTensorStack, TensorDictBase
 from torchdata.stateful_dataloader import StatefulDataLoader
 from torchdata.stateful_dataloader.sampler import StatefulDistributedSampler
@@ -133,14 +132,6 @@ class SyncLLMCollector(SyncDataCollector):
 
         log.info("done init LLMCollector")
 
-    @property
-    def weight_update_sender(self) -> WeightUpdateSenderBase:
-        return self._weight_update_sender
-
-    @weight_update_sender.setter
-    def weight_update_sender(self, value: WeightUpdateSenderBase | None):
-        self._weight_update_sender = value
-
     def _postprocess_for_queue(self, data):
         # local import to avoid vLLM no CUDA GPUs available error
         from torchtune import training
@@ -197,15 +188,6 @@ class SyncLLMCollector(SyncDataCollector):
         total_generated_tokens = seq_lens.sum().item()
         return postprocessed_results, total_generated_tokens
 
-    def update_policy_weights_(
-        self,
-        policy_weights: TensorDictBase | None = None,
-        *,
-        worker_ids: int | list[int] | torch.device | list[torch.device] | None = None,
-        **kwargs,
-    ) -> None:
-        self.weight_update_receiver(policy_weights, **kwargs)
-
     def set_metric_logger(self, logger):
         """Store the MetricLoggerActor handle."""
         print(f"{self._is_collector_zero=} setting metric logger")
@@ -253,15 +235,13 @@ class SyncLLMCollector(SyncDataCollector):
 
         ray.get(self._metric_logger.log_dict.remote(log_dict, step=step_idx))
 
-    async def run(self):
+    def run(self):
         i = 0
         while True:
             self.rollout(i)
             if i % self.cfg.vllm.steps_before_sync == 0:
                 log.info(f"{self.worker_id} about to update weights")
-                await self.weight_update_sender.update_weights.remote(
-                    weights=None, worker_ids=self.worker_id
-                )
+                self.update_policy_weights_()
             i += 1
 
     def rollout(self, idx) -> TensorDictBase:

--- a/torchtune/dev/rl/workers/parameter_servers/vllm.py
+++ b/torchtune/dev/rl/workers/parameter_servers/vllm.py
@@ -38,10 +38,6 @@ class VLLMParameterServer:
         self.world_size = int(os.environ["WORLD_SIZE"])
         assert self.rank == self.world_size - 1
 
-    def register_collector(self, worker_id, handle):
-        self.vllm_worker_handles[worker_id] = handle
-        log.info(f"registered collector {worker_id=}")
-
     def register_model_metadata(self, model_metadata):
         self.model_metadata = model_metadata
         self.state_dict = dict()


### PR DESCRIPTION
1. Makes `VLLMHFWeightUpdateReceiver`  responsible for interacting with `VLLMParameterServer` so that the Collector does not have to take the Sender as an argument
2. Makes `VLLMParameterServer` no longer inherit from `torchrl.collectors.WeightUpdateSenderBase`

This removes this TODO
https://github.com/joecummings/r1-zero/blob/c18ef8c012bf554ae3e6a8235d66821b346b4dd7/scripts/runnable_recipe_ray_vllm_weight_sync.py#L410-L413

unittests for `VLLMParameterServer` are stacked on top in https://github.com/joecummings/r1-zero/pull/54/files