### PR TITLE
Unittests for param server

### DIFF
--- a/tests/torchtune/rl/test_parameter_server.py
+++ b/tests/torchtune/rl/test_parameter_server.py
@@ -1,0 +1,167 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+SKIP_FILE = not (
+    importlib.util.find_spec("ray") is not None
+    and importlib.util.find_spec("transformers") is not None
+    and importlib.util.find_spec("vllm") is not None
+)
+
+
+if not SKIP_FILE:
+
+    import os
+
+    import pytest
+    import ray
+    import torch
+    from omegaconf import OmegaConf
+    from tests.test_utils import gpu_test
+
+    from torchtune.dev.rl.workers import VLLMHFWeightUpdateReceiver, VLLMParameterServer
+    from torchtune.dev.rl.workers.datacollectors import VLLMWorkerWrapper
+    from transformers import AutoModel
+    from vllm import LLM
+
+    @ray.remote(num_cpus=1, num_gpus=1)
+    class DummyTrainer:
+        def __init__(self, env_vars):
+            for k, v in env_vars.items():
+                os.environ[k] = str(v)
+
+            torch.cuda.set_device(torch.device("cuda", 0))
+
+            if not torch.distributed.is_initialized():
+                torch.distributed.init_process_group(
+                    backend="nccl", device_id=torch.device("cuda:0")
+                )
+
+            self.rank = int(os.environ["RANK"])
+            self.model = AutoModel.from_pretrained("gpt2").cuda().bfloat16()
+
+            self.model._apply(lambda t: t.fill_(1.0))
+
+        def get_model_metadata(self):
+            return {k: (v.dtype, v.shape) for k, v in self.model.state_dict().items()}
+
+        def register_parameter_server(self, parameter_server):
+            self.parameter_server = parameter_server
+
+        def sync_weights(self):
+            ray.get(self.parameter_server.acquire_state_dict_lock.remote())
+            self.parameter_server.receive_from_trainer.remote()
+            for k, v in self.model.state_dict().items():
+                torch.distributed.send(v, 1)
+            ray.get(self.parameter_server.release_state_dict_lock.remote())
+
+    @ray.remote(num_cpus=1, num_gpus=1)
+    class DummyCollector:
+        def __init__(self, weight_receiver, tp_size):
+
+            self.inference_server = LLM(
+                "gpt2",
+                enforce_eager=True,
+                dtype="bfloat16",
+                worker_cls=VLLMWorkerWrapper,
+                tensor_parallel_size=tp_size,
+            )
+
+            self.weight_update_receiver = weight_receiver
+            self.weight_update_receiver.register_collector(self)
+
+        def update_policy_weights_(self) -> None:
+            self.weight_update_receiver()
+            torch.cuda.synchronize()
+
+        def check_weights_changed(self, fill_val) -> bool:
+            return self.inference_server.collective_rpc(
+                "_check_weights_changed", args=(fill_val,)
+            )
+
+    class TestParamServer:
+        def _get_env_vars(self, rank):
+            env_vars = {
+                "RANK": rank,
+                "WORLD_SIZE": 2,
+                "MASTER_ADDR": "127.0.0.1",
+                "MASTER_PORT": "29500",
+            }
+            return env_vars
+
+        def _get_config(self, tp_size: int = 1):
+            config_str = f"""
+vllm:
+    tp_size: {tp_size}
+            """
+            cfg = OmegaConf.create(config_str)
+            return cfg
+
+        @gpu_test(gpu_count=2)
+        def test_receive_from_trainer(self) -> None:
+            ray.init(num_cpus=10, num_gpus=2)
+
+            try:
+                trainer_handle = DummyTrainer.remote(self._get_env_vars(0))
+                cfg = self._get_config()
+                ps_handle = VLLMParameterServer.remote(
+                    cfg, None, None, self._get_env_vars(1)
+                )
+                trainer_handle.register_parameter_server.remote(ps_handle)
+                model_metadata = ray.get(trainer_handle.get_model_metadata.remote())
+                ps_handle.register_model_metadata.remote(model_metadata)
+                ps_weights = ray.get(ps_handle._get_server_weights.remote())
+
+                for k, v in model_metadata.items():
+                    assert ps_weights[k].dtype == v[0]
+                    assert ps_weights[k].shape == v[1]
+                    assert torch.equal(ps_weights[k], torch.zeros_like(ps_weights[k]))
+
+                ray.get(trainer_handle.sync_weights.remote())
+
+                updated_ps_weights = ray.get(ps_handle._get_server_weights.remote())
+                for k, v in model_metadata.items():
+                    assert torch.equal(
+                        updated_ps_weights[k], torch.ones_like(updated_ps_weights[k])
+                    )
+            finally:
+                ray.shutdown()
+
+        @gpu_test(gpu_count=4)
+        @pytest.mark.parametrize("tp_size", (1, 2))
+        def test_send_to_generator(self, tp_size) -> None:
+            ray.init(num_cpus=10, num_gpus=4)
+
+            try:
+                from vllm.utils import get_ip, get_open_port
+
+                model = AutoModel.from_pretrained("gpt2").cuda().to(torch.bfloat16)
+                model_metadata = {
+                    k: (v.dtype, v.shape) for k, v in model.state_dict().items()
+                }
+
+                trainer_handle = DummyTrainer.remote(self._get_env_vars(0))
+                ip, port, worker_idx = get_ip(), get_open_port(), 0
+                cfg = self._get_config(tp_size=tp_size)
+                ps_handle = VLLMParameterServer.remote(
+                    cfg, [ip], [port], self._get_env_vars(1)
+                )
+                weight_receiver = VLLMHFWeightUpdateReceiver(
+                    ip, port, model_metadata, ps_handle, worker_idx
+                )
+                collector_handle = DummyCollector.options(num_gpus=tp_size).remote(
+                    weight_receiver, tp_size
+                )
+
+                trainer_handle.register_parameter_server.remote(ps_handle)
+                ray.get(ps_handle.register_model_metadata.remote(model_metadata))
+                ray.get(trainer_handle.sync_weights.remote())
+
+                ray.get(collector_handle.update_policy_weights_.remote())
+                assert all(ray.get(collector_handle.check_weights_changed.remote(1.0)))
+            finally:
+                ray.shutdown()

--- a/tests/torchtune/rl/test_parameter_server.py
+++ b/tests/torchtune/rl/test_parameter_server.py
@@ -62,6 +62,7 @@ if not SKIP_FILE:
     @ray.remote(num_cpus=1, num_gpus=1)
     class DummyCollector:
         def __init__(self, weight_receiver, tp_size):
+            os.environ["VLLM_USE_V1"] = "0"
 
             self.inference_server = LLM(
                 "gpt2",
@@ -76,7 +77,6 @@ if not SKIP_FILE:
 
         def update_policy_weights_(self) -> None:
             self.weight_update_receiver()
-            torch.cuda.synchronize()
 
         def check_weights_changed(self, fill_val) -> bool:
             return self.inference_server.collective_rpc(

--- a/tests/torchtune/rl/test_parameter_server.py
+++ b/tests/torchtune/rl/test_parameter_server.py
@@ -6,162 +6,201 @@
 
 import importlib
 
-SKIP_FILE = not (
-    importlib.util.find_spec("ray") is not None
-    and importlib.util.find_spec("transformers") is not None
-    and importlib.util.find_spec("vllm") is not None
-)
+_has_ray = importlib.util.find_spec("ray") is not None
+_has_vllm = importlib.util.find_spec("vllm") is not None
 
-
-if not SKIP_FILE:
-
-    import os
-
-    import pytest
+if _has_ray:
     import ray
-    import torch
-    from omegaconf import OmegaConf
-    from tests.test_utils import gpu_test
+    from ray import remote
+else:
+    # dummy decorator - never used bc tests are skipped
+    def remote(*args, **kwargs):
+        return lambda cls: cls
 
-    from torchtune.dev.rl.workers import VLLMHFWeightUpdateReceiver, VLLMParameterServer
-    from torchtune.dev.rl.workers.datacollectors import VLLMWorkerWrapper
-    from transformers import AutoModel
-    from vllm import LLM
 
-    @ray.remote(num_cpus=1, num_gpus=1)
-    class DummyTrainer:
-        def __init__(self, env_vars):
-            for k, v in env_vars.items():
-                os.environ[k] = str(v)
+import os
+from typing import Dict
 
-            torch.cuda.set_device(torch.device("cuda", 0))
+import pytest
+import torch
+from omegaconf import OmegaConf
+from tests.test_utils import gpu_test
 
-            if not torch.distributed.is_initialized():
-                torch.distributed.init_process_group(
-                    backend="nccl", device_id=torch.device("cuda:0")
-                )
 
-            self.rank = int(os.environ["RANK"])
-            self.model = AutoModel.from_pretrained("gpt2").cuda().bfloat16()
+@remote(num_cpus=1, num_gpus=1)
+class DummyTrainer:
+    def __init__(self, env_vars):
+        from transformers import AutoModel
 
-            self.model._apply(lambda t: t.fill_(1.0))
+        for k, v in env_vars.items():
+            os.environ[k] = str(v)
 
-        def get_model_metadata(self):
-            return {k: (v.dtype, v.shape) for k, v in self.model.state_dict().items()}
+        torch.cuda.set_device(torch.device("cuda", 0))
 
-        def register_parameter_server(self, parameter_server):
-            self.parameter_server = parameter_server
-
-        def sync_weights(self):
-            ray.get(self.parameter_server.acquire_state_dict_lock.remote())
-            self.parameter_server.receive_from_trainer.remote()
-            for k, v in self.model.state_dict().items():
-                torch.distributed.send(v, 1)
-            ray.get(self.parameter_server.release_state_dict_lock.remote())
-
-    @ray.remote(num_cpus=1, num_gpus=1)
-    class DummyCollector:
-        def __init__(self, weight_receiver, tp_size):
-            os.environ["VLLM_USE_V1"] = "0"
-
-            self.inference_server = LLM(
-                "gpt2",
-                enforce_eager=True,
-                dtype="bfloat16",
-                worker_cls=VLLMWorkerWrapper,
-                tensor_parallel_size=tp_size,
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(
+                backend="nccl", device_id=torch.device("cuda:0")
             )
 
-            self.weight_update_receiver = weight_receiver
-            self.weight_update_receiver.register_collector(self)
+        self.rank = int(os.environ["RANK"])
+        self.model = AutoModel.from_pretrained("gpt2").cuda().bfloat16()
 
-        def update_policy_weights_(self) -> None:
-            self.weight_update_receiver()
+        self.model._apply(lambda t: t.fill_(1.0))
 
-        def check_weights_changed(self, fill_val) -> bool:
-            return self.inference_server.collective_rpc(
-                "_check_weights_changed", args=(fill_val,)
-            )
+    def get_model_metadata(self):
+        return {k: (v.dtype, v.shape) for k, v in self.model.state_dict().items()}
 
-    class TestParamServer:
-        def _get_env_vars(self, rank):
-            env_vars = {
-                "RANK": rank,
-                "WORLD_SIZE": 2,
-                "MASTER_ADDR": "127.0.0.1",
-                "MASTER_PORT": "29500",
-            }
-            return env_vars
+    def register_parameter_server(self, parameter_server):
+        self.parameter_server = parameter_server
 
-        def _get_config(self, tp_size: int = 1):
-            config_str = f"""
+    def sync_weights(self):
+        ray.get(self.parameter_server.acquire_state_dict_lock.remote())
+        self.parameter_server.receive_from_trainer.remote()
+        for k, v in self.model.state_dict().items():
+            torch.distributed.send(v, 1)
+        ray.get(self.parameter_server.release_state_dict_lock.remote())
+
+
+@remote(num_cpus=1, num_gpus=1)
+class DummyCollector:
+    def __init__(self, weight_receiver, tp_size):
+        from torchtune.dev.rl.workers.datacollectors import VLLMWorkerWrapper
+        from vllm import LLM
+        from vllm.model_executor.layers.vocab_parallel_embedding import (
+            VocabParallelEmbedding,
+        )
+
+        os.environ["VLLM_USE_V1"] = "0"
+
+        class TestVLLMWorkerWrapper(VLLMWorkerWrapper):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            def _check_weights_changed(self, fill_val) -> bool:
+                """
+                Check if the weights are updated to fill_val.
+                """
+                weights_updated = True
+                for name, p in self.model_runner.model.named_parameters():
+                    mod, child_name = name.rsplit(".", 1)
+                    parent_module = self.model_runner.model.get_submodule(mod)
+                    # TODO: vLLM pads embeddings with zeros, so not the full embedding will be filled with fill_val
+                    if not isinstance(parent_module, VocabParallelEmbedding):
+                        weights_updated = weights_updated and torch.allclose(
+                            p, torch.empty_like(p).fill_(fill_val)
+                        )
+                return weights_updated
+
+        self.inference_server = LLM(
+            "gpt2",
+            enforce_eager=True,
+            dtype="bfloat16",
+            worker_cls=TestVLLMWorkerWrapper,
+            tensor_parallel_size=tp_size,
+        )
+
+        self.weight_update_receiver = weight_receiver
+        self.weight_update_receiver.register_collector(self)
+
+    def update_policy_weights_(self) -> None:
+        self.weight_update_receiver()
+
+    def check_weights_changed(self, fill_val) -> bool:
+        return self.inference_server.collective_rpc(
+            "_check_weights_changed", args=(fill_val,)
+        )
+
+
+@pytest.mark.skipif(not _has_ray or not _has_vllm, reason="requires ray and vllm")
+class TestParamServer:
+    def _get_env_vars(self, rank, world_size) -> Dict[str, str]:
+        env_vars = {
+            "RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": "29500",
+        }
+        return env_vars
+
+    def _get_config(self, tp_size: int = 1):
+        config_str = f"""
 vllm:
     tp_size: {tp_size}
-            """
-            cfg = OmegaConf.create(config_str)
-            return cfg
+        """
+        cfg = OmegaConf.create(config_str)
+        return cfg
 
-        @gpu_test(gpu_count=2)
-        def test_receive_from_trainer(self) -> None:
-            ray.init(num_cpus=10, num_gpus=2)
+    @gpu_test(gpu_count=2)
+    def test_receive_from_trainer(self) -> None:
+        import ray
+        from torchtune.dev.rl.workers import VLLMParameterServer
 
-            try:
-                trainer_handle = DummyTrainer.remote(self._get_env_vars(0))
-                cfg = self._get_config()
-                ps_handle = VLLMParameterServer.remote(
-                    cfg, None, None, self._get_env_vars(1)
+        ray.init(num_cpus=10, num_gpus=2)
+
+        try:
+            trainer_handle = DummyTrainer.remote(self._get_env_vars(0, 2))
+            cfg = self._get_config()
+            ps_handle = VLLMParameterServer.remote(
+                cfg, None, None, self._get_env_vars(1, 2)
+            )
+            trainer_handle.register_parameter_server.remote(ps_handle)
+            model_metadata = ray.get(trainer_handle.get_model_metadata.remote())
+            ps_handle.register_model_metadata.remote(model_metadata)
+            ps_weights = ray.get(ps_handle._get_server_weights.remote())
+
+            for k, v in model_metadata.items():
+                assert ps_weights[k].dtype == v[0]
+                assert ps_weights[k].shape == v[1]
+                assert torch.equal(ps_weights[k], torch.zeros_like(ps_weights[k]))
+
+            ray.get(trainer_handle.sync_weights.remote())
+
+            updated_ps_weights = ray.get(ps_handle._get_server_weights.remote())
+            for k, v in model_metadata.items():
+                assert torch.equal(
+                    updated_ps_weights[k], torch.ones_like(updated_ps_weights[k])
                 )
-                trainer_handle.register_parameter_server.remote(ps_handle)
-                model_metadata = ray.get(trainer_handle.get_model_metadata.remote())
-                ps_handle.register_model_metadata.remote(model_metadata)
-                ps_weights = ray.get(ps_handle._get_server_weights.remote())
+        finally:
+            ray.shutdown()
 
-                for k, v in model_metadata.items():
-                    assert ps_weights[k].dtype == v[0]
-                    assert ps_weights[k].shape == v[1]
-                    assert torch.equal(ps_weights[k], torch.zeros_like(ps_weights[k]))
+    @gpu_test(gpu_count=4)
+    @pytest.mark.parametrize("tp_size", (1, 2))
+    def test_send_to_generator(self, tp_size) -> None:
+        import ray
 
-                ray.get(trainer_handle.sync_weights.remote())
+        ray.init(num_cpus=10, num_gpus=2 + tp_size)
 
-                updated_ps_weights = ray.get(ps_handle._get_server_weights.remote())
-                for k, v in model_metadata.items():
-                    assert torch.equal(
-                        updated_ps_weights[k], torch.ones_like(updated_ps_weights[k])
-                    )
-            finally:
-                ray.shutdown()
+        try:
+            from torchtune.dev.rl.workers import (
+                VLLMHFWeightUpdateReceiver,
+                VLLMParameterServer,
+            )
+            from transformers import AutoModel
+            from vllm.utils import get_ip, get_open_port
 
-        @gpu_test(gpu_count=4)
-        @pytest.mark.parametrize("tp_size", (1, 2))
-        def test_send_to_generator(self, tp_size) -> None:
-            ray.init(num_cpus=10, num_gpus=4)
+            model = AutoModel.from_pretrained("gpt2").cuda().to(torch.bfloat16)
+            model_metadata = {
+                k: (v.dtype, v.shape) for k, v in model.state_dict().items()
+            }
 
-            try:
-                from vllm.utils import get_ip, get_open_port
+            trainer_handle = DummyTrainer.remote(self._get_env_vars(0, 2))
+            ip, port, worker_idx = get_ip(), get_open_port(), 0
+            cfg = self._get_config(tp_size=tp_size)
+            ps_handle = VLLMParameterServer.remote(
+                cfg, [ip], [port], self._get_env_vars(1, 2)
+            )
+            weight_receiver = VLLMHFWeightUpdateReceiver(
+                ip, port, model_metadata, ps_handle, worker_idx
+            )
+            collector_handle = DummyCollector.options(num_gpus=tp_size).remote(
+                weight_receiver, tp_size
+            )
 
-                model = AutoModel.from_pretrained("gpt2").cuda().to(torch.bfloat16)
-                model_metadata = {
-                    k: (v.dtype, v.shape) for k, v in model.state_dict().items()
-                }
+            trainer_handle.register_parameter_server.remote(ps_handle)
+            ray.get(ps_handle.register_model_metadata.remote(model_metadata))
+            ray.get(trainer_handle.sync_weights.remote())
 
-                trainer_handle = DummyTrainer.remote(self._get_env_vars(0))
-                ip, port, worker_idx = get_ip(), get_open_port(), 0
-                cfg = self._get_config(tp_size=tp_size)
-                ps_handle = VLLMParameterServer.remote(
-                    cfg, [ip], [port], self._get_env_vars(1)
-                )
-                weight_receiver = VLLMHFWeightUpdateReceiver(
-                    ip, port, model_metadata, ps_handle, worker_idx
-                )
-                collector_handle = DummyCollector.options(num_gpus=tp_size).remote(
-                    weight_receiver, tp_size
-                )
-
-                trainer_handle.register_parameter_server.remote(ps_handle)
-                ray.get(ps_handle.register_model_metadata.remote(model_metadata))
-                ray.get(trainer_handle.sync_weights.remote())
-
-                ray.get(collector_handle.update_policy_weights_.remote())
-                assert all(ray.get(collector_handle.check_weights_changed.remote(1.0)))
-            finally:
-                ray.shutdown()
+            ray.get(collector_handle.update_policy_weights_.remote())
+            assert all(ray.get(collector_handle.check_weights_changed.remote(1.0)))
+        finally:
+            ray.shutdown()

--- a/torchtune/dev/rl/workers/__init__.py
+++ b/torchtune/dev/rl/workers/__init__.py
@@ -1,5 +1,12 @@
-from .datacollectors import SyncLLMCollector
-from .metric_logger import MetricLoggerActor
-from .parameter_servers import VLLMParameterServer
-from .ref_actor import RefActor
-from .trainers import PyTorchActorModel
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .datacollectors import SyncLLMCollector  # noqa: F401
+from .metric_logger import MetricLoggerActor  # noqa: F401
+from .parameter_servers import VLLMParameterServer  # noqa: F401
+from .ref_actor import RefActor  # noqa: F401
+from .trainers import PyTorchActorModel  # noqa: F401
+from .weight_updaters import VLLMHFWeightUpdateReceiver  # noqa: F401

--- a/torchtune/dev/rl/workers/datacollectors/sync.py
+++ b/torchtune/dev/rl/workers/datacollectors/sync.py
@@ -28,6 +28,7 @@ from torchtune import utils
 from torchtune.dev.rl.datatypes import Trajectory
 from torchtune.dev.rl.utils import stateless_init_process_group
 from vllm import LLM
+from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.worker.worker import Worker
 
 log = utils.get_logger()
@@ -426,3 +427,18 @@ class VLLMWorkerWrapper(Worker):
         )
         self.policy_version = self.version
         torch.cuda.synchronize()
+
+    def _check_weights_changed(self, fill_val) -> bool:
+        """
+        Check if the weights are updated to fill_val.
+        """
+        weights_updated = True
+        for name, p in self.model_runner.model.named_parameters():
+            mod, child_name = name.rsplit(".", 1)
+            parent_module = self.model_runner.model.get_submodule(mod)
+            # TODO: vLLM pads embeddings with zeros, so not the full embedding will be filled with fill_val
+            if not isinstance(parent_module, VocabParallelEmbedding):
+                weights_updated = weights_updated and torch.allclose(
+                    p, torch.empty_like(p).fill_(fill_val)
+                )
+        return weights_updated

--- a/torchtune/dev/rl/workers/weight_updaters/__init__.py
+++ b/torchtune/dev/rl/workers/weight_updaters/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .sync import SyncLLMCollector, VLLMWorkerWrapper  # noqa: F401
+from .weight_updater import VLLMHFWeightUpdateReceiver  # noqa: F401

--- a/torchtune/dev/rl/workers/weight_updaters/weight_updater.py
+++ b/torchtune/dev/rl/workers/weight_updaters/weight_updater.py
@@ -1,0 +1,59 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import ray
+from torchrl.collectors import WeightUpdateReceiverBase
+
+
+class VLLMHFWeightUpdateReceiver(WeightUpdateReceiverBase):
+    def __init__(
+        self, master_address, master_port, model_metadata, param_server, worker_idx
+    ):
+        self.master_address = master_address
+        self.master_port = master_port
+        self.model_metadata = model_metadata
+        self.initialized_group = None
+        self.param_server = param_server
+        self.worker_idx = worker_idx
+
+    def _get_server_weights(self):
+        return None
+
+    def _get_local_weights(self):
+        # We don't implement this because we let vLLM's update_weights API handle everything for now
+        return None
+
+    def _maybe_map_weights(self, server_weights, local_weights):
+        # vLLM update_weights function handles the mapping from huggingface
+        # so we don't implement this for now
+        return None
+
+    def _update_local_weights(self, local_weights, mapped_weights):
+        should_update = not ray.get(
+            self.param_server._skip_update.remote(self.worker_idx)
+        )
+        if should_update:
+            self.param_server._sync_weights_with_worker.remote(self.worker_idx)
+            inference_server = self.collector.inference_server
+            if self.initialized_group is None:
+                weight_sync_world_size = (
+                    inference_server.llm_engine.parallel_config.tensor_parallel_size + 1
+                )
+                inference_server.collective_rpc(
+                    "init_weight_update_group",
+                    args=(
+                        self.master_address,
+                        self.master_port,
+                        1,
+                        weight_sync_world_size,
+                    ),
+                )
+                self.initialized_group = True
+
+            for k, (dtype, shape) in self.model_metadata.items():
+                inference_server.collective_rpc("update_weight", args=(k, dtype, shape))
+
+            inference_server.collective_rpc("update_policy_version")


### PR DESCRIPTION


1. Moves `VLLMHFWeightUpdateReceiver` from the main script into its own file in `torchtune.dev.rl.workers.weight_updater` (so it can be imported from the test file)
2. Adds a method to `VLLMWorkerWrapper` similar to [this](https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/rlhf_utils.py#L97-L105) for testing
    - vllm pads embedding matrices with row of zeros see [here](https://github.com/vllm-project/vllm/blob/32d4b669d00d50ad084af128b9c01a5583fb2b7d/vllm/model_executor/layers/vocab_parallel_embedding.py#L400-L401)  (that method only works because it's only checking that the weights were updated to 0)
    - I skip checking the embedding weights changed for now to avoid dealing with this 😅 