### PR TITLE
Fix termination condition for RefActor and Collector

### DIFF
--- a/recipes/dev/async_grpo_full_finetune_distributed.py
+++ b/recipes/dev/async_grpo_full_finetune_distributed.py
@@ -332,7 +332,7 @@ class RayGRPORecipe(OrchestrationRecipeInterface):
                     policy=vllm_generate,
                     worker_id=i,
                     dialog_turns_per_batch=1,
-                    total_dialog_turns=1000,
+                    total_dialog_turns=-1,
                     reset_at_each_iter=True,
                     queue=self.rollout_queue,
                     weight_update_receiver=weight_update_receivers[i],
@@ -362,7 +362,8 @@ class RayGRPORecipe(OrchestrationRecipeInterface):
         rollout_handles = [worker.run.remote() for worker in self.rollout_workers]
         ref_handles = [worker.run.remote() for worker in self.ref_workers]
         worker_handles = [worker.train.remote() for worker in self.actor_workers]
-        ray.get(rollout_handles + ref_handles + worker_handles)
+        ray.get(worker_handles)
+        [ray.kill(w) for w in self.rollout_workers + self.ref_workers]
         ray.get(self.actor_workers[0].cleanup.remote())
 
     def stop_ray(self):

--- a/torchtune/dev/rl/workers/datacollectors/sync.py
+++ b/torchtune/dev/rl/workers/datacollectors/sync.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import time
 from functools import partial
 from typing import Any, Callable, Dict, Optional
@@ -5,8 +11,6 @@ from typing import Any, Callable, Dict, Optional
 import ray
 import torch
 import torch.distributed
-import torchtune.training as training
-import vllm
 
 from omegaconf import DictConfig, ListConfig
 
@@ -21,11 +25,10 @@ from torchrl.collectors import (
     WeightUpdateSenderBase,
 )
 
-from torchrl.envs import LLMEnv
-from torchtune import config, utils
+from torchtune import utils
 from torchtune.dev.rl.datatypes import Trajectory
 from torchtune.dev.rl.utils import stateless_init_process_group
-from vllm import LLM, SamplingParams
+from vllm import LLM
 from vllm.worker.worker import Worker
 
 log = utils.get_logger()
@@ -251,14 +254,15 @@ class SyncLLMCollector(SyncDataCollector):
         ray.get(self._metric_logger.log_dict.remote(log_dict, step=step_idx))
 
     async def run(self):
-        num_steps = (self.cfg.num_steps // self.cfg.vllm.num_workers) + 1
-        for i in range(num_steps):
+        i = 0
+        while True:
             self.rollout(i)
             if i % self.cfg.vllm.steps_before_sync == 0:
                 log.info(f"{self.worker_id} about to update weights")
                 await self.weight_update_sender.update_weights.remote(
                     weights=None, worker_ids=self.worker_id
                 )
+            i += 1
 
     def rollout(self, idx) -> TensorDictBase:
         if self.reset_at_each_iter or self._shuttle is None:

--- a/torchtune/dev/rl/workers/ref_actor.py
+++ b/torchtune/dev/rl/workers/ref_actor.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Any, Dict
 
 import ray
@@ -172,13 +178,13 @@ class RefActor:
 
         # Per-function rewards and successes
         for func_name, func_mean in zip(function_names, rewards_mean_per_func):
-            log_dict[f"ref_actor_rewards/rewards_func_{func_name}_mean"] = (
-                func_mean.item()
-            )
+            log_dict[
+                f"ref_actor_rewards/rewards_func_{func_name}_mean"
+            ] = func_mean.item()
         for func_name, func_mean in zip(function_names, successes_mean_per_func):
-            log_dict[f"ref_actor_rewards/successes_func_{func_name}_mean"] = (
-                func_mean.item()
-            )
+            log_dict[
+                f"ref_actor_rewards/successes_func_{func_name}_mean"
+            ] = func_mean.item()
 
         ray.get(self._metric_logger.log_dict.remote(log_dict, step=step_idx))
 
@@ -188,9 +194,6 @@ class RefActor:
         log.info("running ref actor")
         idx = 0
         while True:
-            if idx == self.cfg.num_steps:
-                break
-
             # Start measuring total step time
             time_step_start = time.perf_counter()
             trajectory = None


### PR DESCRIPTION
`RefActor`/`Collector` get `ray.kill`-ed when trainer has done `config.num_steps` steps

Policy age issue is fixed:
<img width="498" alt="Screenshot 2025-04-23 at 7 41 27 PM" src="https://github.com/user-attachments/assets/22702626-9b2d-439b-a862-20af427e6036" />

<img width="1408" alt="Screenshot 2025-04-23 at 7 41 49 PM" src="https://github.com/user-attachments/assets/7f410329-eff1-4d95-9e94-ba858ea33219" />
