### PR TITLE
Add new model artifacts to work with vLLM (and flex attention)

### DIFF
--- a/tests/cache_artifacts.sh
+++ b/tests/cache_artifacts.sh
@@ -19,8 +19,13 @@ SMALL_MODEL_URLS=(
     "https://ossci-datasets.s3.amazonaws.com/torchtune/small-ckpt-tune-llama3-05052024.pt"
     "https://ossci-datasets.s3.amazonaws.com/torchtune/small-ckpt-hf-reward-07122024.pt"
     "https://ossci-datasets.s3.amazonaws.com/torchtune/small-ckpt-meta-vision-10172024.pt"
-    "https://ossci-datasets.s3.amazonaws.com/torchtune/small-ckpt-hf-vision-10172024.pt"
-
+    "https://ossci-datasets.s3.amazonaws.com/torchtune/llama3-hf-04232025/config.json"
+    "https://ossci-datasets.s3.amazonaws.com/torchtune/llama3-hf-04232025/generation_config.json"
+    "https://ossci-datasets.s3.amazonaws.com/torchtune/llama3-hf-04232025/model.safetensors"
+    "https://ossci-datasets.s3.amazonaws.com/torchtune/llama3-hf-04232025/model.safetensors.index.json"
+    "https://ossci-datasets.s3.amazonaws.com/torchtune/llama3-hf-04232025/special_tokens_map.json"
+    "https://ossci-datasets.s3.amazonaws.com/torchtune/llama3-hf-04232025/tokenizer.json"
+    "https://ossci-datasets.s3.amazonaws.com/torchtune/llama3-hf-04232025/tokenizer_config.json"
 )
 FULL_MODEL_URL=("s3://pytorch-multimodal/llama2-7b-torchtune.pt")
 TOKENIZER_URLS=(

--- a/tests/cache_artifacts.sh
+++ b/tests/cache_artifacts.sh
@@ -76,13 +76,24 @@ fi
 # Sanity check debug log
 echo "Expected artifacts for test run are:"
 for url in "${S3_URLS[@]}"; do
-    echo "$(basename "$url")"
+    if [[ "$url" == *"llama3-hf-04232025"* ]]; then
+        to_print="llama3-hf-04-23-2025/"$(basename "$url")
+        echo $to_print
+    else
+        echo "$(basename "$url")"
+    fi
+
 done
 
 # Download relevant files from S3 to local
 mkdir -p $LOCAL_DIR
 for S3_URL in "${S3_URLS[@]}"; do
-    FILE_NAME=$(basename "$S3_URL")
+    # TODO: this is a horrible hack
+    if [[ "$S3_URL" == *"llama3-hf-04232025"* ]]; then
+        FILE_NAME="llama3-hf-04-23-2025/"$(basename "$S3_URL")
+    else
+        FILE_NAME=$(basename "$S3_URL")
+    fi
 
     # Check if file already exists locally
     if [ -e "$LOCAL_DIR/$FILE_NAME" ]; then
@@ -97,7 +108,8 @@ for S3_URL in "${S3_URLS[@]}"; do
             fi
         # For https: download with curl
         else
-            cp_cmd="curl --output ${LOCAL_DIR}/${FILE_NAME} ${S3_URL}"
+            cp_cmd="curl --create-dirs --output ${LOCAL_DIR}/${FILE_NAME} ${S3_URL}"
+            echo $cp_cmd
         fi
         bash -c "${cp_cmd}"
         # Check if download was successful

--- a/tests/cache_artifacts.sh
+++ b/tests/cache_artifacts.sh
@@ -77,7 +77,7 @@ fi
 echo "Expected artifacts for test run are:"
 for url in "${S3_URLS[@]}"; do
     if [[ "$url" == *"llama3-hf-04232025"* ]]; then
-        to_print="llama3-hf-04-23-2025/"$(basename "$url")
+        to_print="llama3-hf-04232025/"$(basename "$url")
         echo $to_print
     else
         echo "$(basename "$url")"
@@ -90,7 +90,7 @@ mkdir -p $LOCAL_DIR
 for S3_URL in "${S3_URLS[@]}"; do
     # TODO: this is a horrible hack
     if [[ "$S3_URL" == *"llama3-hf-04232025"* ]]; then
-        FILE_NAME="llama3-hf-04-23-2025/"$(basename "$S3_URL")
+        FILE_NAME="llama3-hf-04232025/"$(basename "$S3_URL")
     else
         FILE_NAME=$(basename "$S3_URL")
     fi

--- a/tests/recipes/utils.py
+++ b/tests/recipes/utils.py
@@ -128,7 +128,7 @@ def llama3_test_config() -> List[str]:
     ]
 
 
-def llama3_test_config_v2() -> List[str]:
+def llama3_test_config_137m() -> List[str]:
     """
     Test config with slightly larger embed dim to be paged and flex attention friendly
     """
@@ -291,7 +291,7 @@ def write_hf_vision_ckpt_config(ckpt_dir: str):
 MODEL_TEST_CONFIGS = {
     "llama2": llama2_test_config(),
     "llama3": llama3_test_config(),
-    "llama3_v2": llama3_test_config_v2(),
+    "llama3_137M": llama3_test_config_137m(),
     "llama2_lora": lora_llama2_test_config(
         lora_attn_modules=["q_proj", "k_proj", "v_proj", "output_proj"],
         apply_lora_to_mlp=False,

--- a/tests/recipes/utils.py
+++ b/tests/recipes/utils.py
@@ -128,6 +128,22 @@ def llama3_test_config() -> List[str]:
     ]
 
 
+def llama3_test_config_v2() -> List[str]:
+    """
+    Test config with slightly larger embed dim to be paged and flex attention friendly
+    """
+    return [
+        "model._component_=torchtune.models.llama3.llama3",
+        "model.vocab_size=128_256",
+        "model.num_layers=2",
+        "model.num_heads=4",
+        "model.embed_dim=512",
+        "model.max_seq_len=1024",
+        "model.norm_eps=1e-5",
+        "model.num_kv_heads=2",
+    ]
+
+
 def llama3_2_vision_test_config() -> List[str]:
     return [
         "model=tests.recipes.utils.dummy_vision_model",
@@ -275,6 +291,7 @@ def write_hf_vision_ckpt_config(ckpt_dir: str):
 MODEL_TEST_CONFIGS = {
     "llama2": llama2_test_config(),
     "llama3": llama3_test_config(),
+    "llama3_v2": llama3_test_config_v2(),
     "llama2_lora": lora_llama2_test_config(
         lora_attn_modules=["q_proj", "k_proj", "v_proj", "output_proj"],
         apply_lora_to_mlp=False,


### PR DESCRIPTION
Our previous Llama3 test models have embed_dim=64 and num_heads=8, so head_dim=8. This is too small for both paged attention and flex attention kernels. Uploaded a new model with corresponding HF configs that can be used for testing with vLLM