### PR TITLE
Address 68 and 50

### DIFF
--- a/recipes/configs/dev/qwen3B_async_grpo.yaml
+++ b/recipes/configs/dev/qwen3B_async_grpo.yaml
@@ -73,6 +73,8 @@ inference:
   total_batch_size: ${eval:'${inference.batch_size} * ${inference.group_size}'}
   steps_before_sync: 1
   queue_maxsize: ${eval:'${orchestration.num_inference_workers} * ${training.steps_before_sync}'}
+  # gpu_memory_utilization for vllm kv cache
+  gpu_memory_utilization: 0.9
 
 postprocessing:
   device_type: cuda

--- a/torchtune/dev/rl/workers/datacollectors/sync.py
+++ b/torchtune/dev/rl/workers/datacollectors/sync.py
@@ -67,6 +67,7 @@ class SyncLLMCollector(SyncDataCollector):
 
         self.tp_size = self.cfg.inference.tp_size
         self.batch_size = self.cfg.inference.batch_size
+        self.gpu_memory_utilization = self.cfg.inference.gpu_memory_utilization
         self._sequence_counter = 0  # Used to assign unique sequence IDs to each sample
 
         self.inference_server = LLM(
@@ -76,6 +77,7 @@ class SyncLLMCollector(SyncDataCollector):
             dtype="bfloat16",
             worker_cls=VLLMWorkerWrapper,
             tensor_parallel_size=self.tp_size,
+            gpu_memory_utilization=self.gpu_memory_utilization,
         )
 
         # local import below LLM call to avoid vLLM no CUDA GPUs available error


### PR DESCRIPTION
Address https://github.com/joecummings/r1-zero/issues/68 and https://github.com/joecummings/r1-zero/issues/50


For #68, the OOM was in DataCollector.run
- `DataCollector.run` / `PostProcessingActor.run` were not being `ray.get` so if they failed they would not cause the script to terminate
- In this PR all the TrainActor/Dataollector/PostprocessingActor `run` handles are waited on, if any terminates with a `RayActorError` all actors are (non gracefully) killed
